### PR TITLE
Use dnsname in the httpd redirect, if it is set

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -148,7 +148,7 @@ if [ "x${httpd}" != "xinstall ok installed" ]; then
 		cat > /etc/lighttpd/conf-enabled/10-unifi-redirect.conf <<_EOF
 \$HTTP["scheme"] == "http" {
     \$HTTP["host"] =~ ".*" {
-        url.redirect = (".*" => "https://%0:8443")
+        url.redirect = (".*" => "https://${dnsname:-\%0}:8443")
     }
 }
 _EOF


### PR DESCRIPTION
Without this the redirect may be sent to the host's public IP, resulting in a certificate error.

Steps:
- install VM per instructions
- navigate in browser to http://<external static IP>
- observer redirect to https://<external static IP>:8443 resulting in certificate error